### PR TITLE
feat: API認証の実装（書き込み系エンドポイント）

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class AuthController extends Controller
+{
+    /**
+     * ログイン処理
+     * 
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function login(Request $request)
+    {
+        $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+            'device_name' => 'required',
+        ]);
+
+        $user = User::where('email', $request->email)->first();
+
+        if (! $user || ! Hash::check($request->password, $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => ['認証情報が正しくありません。'],
+            ]);
+        }
+
+        // 既存のトークンを削除（1デバイス1トークン制限）
+        $user->tokens()->where('name', $request->device_name)->delete();
+
+        return response()->json([
+            'user' => $user,
+            'token' => $user->createToken($request->device_name)->plainTextToken,
+        ]);
+    }
+
+    /**
+     * ログアウト処理
+     * 
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function logout(Request $request)
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json([
+            'message' => 'ログアウトしました。',
+        ]);
+    }
+
+    /**
+     * 現在のユーザー情報取得
+     * 
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function me(Request $request)
+    {
+        return response()->json($request->user());
+    }
+}

--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -25,13 +25,13 @@ class AuthController extends Controller
 
         $user = User::where('email', $request->email)->first();
 
-        // タイミング攻撃対策：ユーザーが存在しない場合でもハッシュ検証を実行
-        $isValidPassword = $user ? Hash::check($request->password, $user->password) : false;
+        // タイミング攻撃対策：ユーザーが存在しない場合でも同等の計算時間を確保
+        // bcryptのデフォルトハッシュを使用（Laravelのデフォルトパスワード）
+        $dummyHash = '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi';
         
-        // ダミーのハッシュ検証でタイミングを均一化
-        if (!$user) {
-            Hash::check('dummy_password', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi');
-        }
+        // ユーザーが存在する場合は実際のハッシュ、存在しない場合はダミーハッシュで検証
+        $hashToCheck = $user ? $user->password : $dummyHash;
+        $isValidPassword = Hash::check($request->password, $hashToCheck);
 
         if (! $user || ! $isValidPassword) {
             throw ValidationException::withMessages([

--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -25,7 +25,15 @@ class AuthController extends Controller
 
         $user = User::where('email', $request->email)->first();
 
-        if (! $user || ! Hash::check($request->password, $user->password)) {
+        // タイミング攻撃対策：ユーザーが存在しない場合でもハッシュ検証を実行
+        $isValidPassword = $user ? Hash::check($request->password, $user->password) : false;
+        
+        // ダミーのハッシュ検証でタイミングを均一化
+        if (!$user) {
+            Hash::check('dummy_password', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi');
+        }
+
+        if (! $user || ! $isValidPassword) {
             throw ValidationException::withMessages([
                 'email' => ['認証情報が正しくありません。'],
             ]);

--- a/backend/database/seeders/TestUserSeeder.php
+++ b/backend/database/seeders/TestUserSeeder.php
@@ -16,6 +16,9 @@ class TestUserSeeder extends Seeder
     {
         DB::table('users')->truncate();
 
+        // テスト用の固定ユーザーを最初に作成
+        $this->createTestUsers();
+
         $batchSize = 500; // 100から500に増加
         $totalUsers = 1000; // テスト用に1000件のまま
         $batches = ceil($totalUsers / $batchSize);
@@ -76,5 +79,58 @@ class TestUserSeeder extends Seeder
             $this->command->error('TestUserSeeder failed: '.$e->getMessage());
             throw $e;
         }
+    }
+
+    /**
+     * テスト用の固定ユーザーを作成
+     */
+    private function createTestUsers(): void
+    {
+        $hashedPassword = Hash::make('password');
+        $currentTime = now();
+
+        // 管理者ユーザー
+        DB::table('users')->insert([
+            'name' => 'テスト管理者',
+            'email' => 'admin@example.com',
+            'email_verified_at' => $currentTime,
+            'password' => $hashedPassword,
+            'phone_number' => '090-1234-5678',
+            'address' => '東京都千代田区1-1-1',
+            'birth_date' => '1990-01-01',
+            'gender' => 'male',
+            'membership_status' => 'active',
+            'notes' => 'テスト用管理者アカウント',
+            'profile_image' => null,
+            'points' => 10000,
+            'last_login_at' => $currentTime,
+            'remember_token' => Str::random(10),
+            'created_at' => $currentTime,
+            'updated_at' => $currentTime,
+        ]);
+
+        // 一般ユーザー
+        DB::table('users')->insert([
+            'name' => 'テストユーザー',
+            'email' => 'user@example.com',
+            'email_verified_at' => $currentTime,
+            'password' => $hashedPassword,
+            'phone_number' => '090-9876-5432',
+            'address' => '大阪府大阪市中央区1-2-3',
+            'birth_date' => '1995-05-15',
+            'gender' => 'female',
+            'membership_status' => 'active',
+            'notes' => 'テスト用一般アカウント',
+            'profile_image' => null,
+            'points' => 5000,
+            'last_login_at' => $currentTime,
+            'remember_token' => Str::random(10),
+            'created_at' => $currentTime,
+            'updated_at' => $currentTime,
+        ]);
+
+        $this->command->info('テスト用固定ユーザーを作成しました:');
+        $this->command->info('- admin@example.com / password');
+        $this->command->info('- user@example.com / password');
     }
 }

--- a/backend/tests/Feature/AuthenticationTest.php
+++ b/backend/tests/Feature/AuthenticationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正しい認証情報でログインできることをテスト
+     */
+    public function test_user_can_login_with_valid_credentials()
+    {
+        $user = User::factory()->create([
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'device_name' => 'test-device',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'user' => ['id', 'name', 'email'],
+                'token',
+            ]);
+    }
+
+    /**
+     * 間違ったパスワードでログインできないことをテスト
+     */
+    public function test_user_cannot_login_with_invalid_password()
+    {
+        $user = User::factory()->create([
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => 'test@example.com',
+            'password' => 'wrong-password',
+            'device_name' => 'test-device',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('email');
+    }
+
+    /**
+     * 存在しないユーザーでログインできないことをテスト
+     */
+    public function test_user_cannot_login_with_nonexistent_email()
+    {
+        $response = $this->postJson('/api/login', [
+            'email' => 'nonexistent@example.com',
+            'password' => 'password',
+            'device_name' => 'test-device',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('email');
+    }
+
+    /**
+     * 認証なしで書き込み系APIにアクセスできないことをテスト
+     */
+    public function test_unauthenticated_user_cannot_access_protected_routes()
+    {
+        $response = $this->postJson('/api/users', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * 認証ありで書き込み系APIにアクセスできることをテスト
+     */
+    public function test_authenticated_user_can_access_protected_routes()
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/users', [
+            'name' => 'New User',
+            'email' => 'newuser@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(201);
+    }
+
+    /**
+     * 読み取り専用APIは認証なしでアクセスできることをテスト
+     */
+    public function test_public_routes_are_accessible_without_authentication()
+    {
+        User::factory()->count(5)->create();
+
+        $response = $this->getJson('/api/users');
+        $response->assertOk();
+
+        $response = $this->getJson('/api/users/export');
+        $response->assertOk();
+    }
+
+    /**
+     * ログアウトができることをテスト
+     */
+    public function test_user_can_logout()
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/logout');
+        $response->assertOk();
+
+        // トークンが無効化されていることを確認
+        $this->assertCount(0, $user->fresh()->tokens);
+    }
+
+    /**
+     * CSVインポートに認証が必要なことをテスト
+     */
+    public function test_csv_import_requires_authentication()
+    {
+        $response = $this->postJson('/api/users/import');
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * バルク削除に認証が必要なことをテスト
+     */
+    public function test_bulk_delete_requires_authentication()
+    {
+        $response = $this->postJson('/api/users/bulk-delete', [
+            'user_ids' => [1, 2, 3],
+        ]);
+        $response->assertUnauthorized();
+    }
+}

--- a/docs/AUTH_SETUP.md
+++ b/docs/AUTH_SETUP.md
@@ -1,0 +1,92 @@
+# API認証セットアップガイド
+
+## 概要
+このシステムはLaravel Sanctumを使用したトークンベースの認証を実装しています。
+
+## セットアップ手順
+
+### 1. マイグレーション実行
+```bash
+docker compose exec backend php artisan migrate
+```
+
+### 2. テストユーザーの作成
+```bash
+docker compose exec backend php artisan db:seed --class=TestUserSeeder
+```
+
+## テストアカウント
+
+以下のテストアカウントが利用可能です：
+
+| ユーザータイプ | メールアドレス | パスワード | 説明 |
+|------------|--------------|----------|------|
+| 管理者 | admin@example.com | password | 全機能にアクセス可能 |
+| 一般ユーザー | user@example.com | password | 標準的な権限 |
+
+## API認証の使用方法
+
+### ログイン
+```bash
+curl -X POST http://localhost:8000/api/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "admin@example.com",
+    "password": "password",
+    "device_name": "web"
+  }'
+```
+
+レスポンス:
+```json
+{
+  "user": { ... },
+  "token": "1|xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+### 認証が必要なAPIへのアクセス
+```bash
+curl -X POST http://localhost:8000/api/users \
+  -H "Authorization: Bearer YOUR_TOKEN_HERE" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "新規ユーザー",
+    "email": "new@example.com"
+  }'
+```
+
+### ログアウト
+```bash
+curl -X POST http://localhost:8000/api/logout \
+  -H "Authorization: Bearer YOUR_TOKEN_HERE"
+```
+
+## フロントエンドでの使用
+
+1. ログインページ（`/login`）にアクセス
+2. テストアカウントでログイン
+3. トークンは自動的にlocalStorageに保存
+4. 以降のAPIリクエストには自動的に認証ヘッダーが付与
+
+## 認証が必要なエンドポイント
+
+以下のエンドポイントは認証が必須です：
+
+- `POST /api/users` - ユーザー作成
+- `PUT /api/users/{id}` - ユーザー更新
+- `DELETE /api/users/{id}` - ユーザー削除
+- `POST /api/users/import` - CSVインポート
+- `POST /api/users/bulk-delete` - 一括削除
+- `POST /api/users/bulk-export` - 一括エクスポート
+
+## トラブルシューティング
+
+### 401 Unauthorizedエラー
+- トークンが正しく設定されているか確認
+- トークンの有効期限が切れていないか確認
+- `Authorization: Bearer TOKEN`形式でヘッダーが設定されているか確認
+
+### マイグレーションエラー
+- データベース接続を確認
+- `docker compose exec backend php artisan migrate:fresh`で再実行

--- a/docs/AUTH_SETUP.md
+++ b/docs/AUTH_SETUP.md
@@ -69,7 +69,9 @@ curl -X POST http://localhost:8000/api/logout \
 3. トークンは自動的にlocalStorageに保存
 4. 以降のAPIリクエストには自動的に認証ヘッダーが付与
 
-## 認証が必要なエンドポイント
+## エンドポイントの認証要件
+
+### 認証が必要なエンドポイント（書き込み系）
 
 以下のエンドポイントは認証が必須です：
 
@@ -77,8 +79,23 @@ curl -X POST http://localhost:8000/api/logout \
 - `PUT /api/users/{id}` - ユーザー更新
 - `DELETE /api/users/{id}` - ユーザー削除
 - `POST /api/users/import` - CSVインポート
+- `POST /api/users/check-duplicates` - CSV重複チェック
 - `POST /api/users/bulk-delete` - 一括削除
 - `POST /api/users/bulk-export` - 一括エクスポート
+- `POST /api/users/bulk-export-fast` - 高速一括エクスポート
+
+### 認証不要のエンドポイント（読み取り専用）
+
+以下のエンドポイントは認証なしでアクセス可能です：
+
+- `GET /api/users` - ユーザー一覧取得
+- `GET /api/users/{id}` - ユーザー詳細取得
+- `GET /api/users/export` - CSVエクスポート
+- `GET /api/users/export-fast` - 高速CSVエクスポート
+- `GET /api/users/sample-csv` - サンプルCSVダウンロード
+- `GET /api/users/status-counts` - ステータス別カウント取得
+- `GET /api/pagination` - ページネーション付きユーザー一覧
+- `GET /api/pagination/status-counts` - ページネーション用ステータスカウント
 
 ## トラブルシューティング
 

--- a/docs/issues/issue-30-api-authentication.md
+++ b/docs/issues/issue-30-api-authentication.md
@@ -1,0 +1,67 @@
+# Issue #30: API認証の実装（書き込み系エンドポイント）
+
+## 問題の概要
+現在、書き込み系APIエンドポイント（ユーザー作成/更新/削除、CSVインポート、バルク操作）が認証なしで公開されており、重大なセキュリティリスクとなっている。
+
+## 影響範囲
+- **ファイル**: `backend/routes/api.php`
+- **影響度**: Critical（セキュリティ脆弱性）
+- **対象エンドポイント**:
+  - POST /users（作成）
+  - PUT /users/{id}（更新）
+  - DELETE /users/{id}（削除）
+  - POST /users/import（CSVインポート）
+  - POST /users/bulk-delete（一括削除）
+  - POST /users/bulk-export（一括エクスポート）
+
+## 詳細な問題点
+
+現在の`routes/api.php`では、書き込み系エンドポイントがレート制限のみで保護されている：
+```php
+Route::middleware(['throttle:60,1'])->group(function () {
+    Route::post('users', [UserController::class, 'store']);
+    Route::put('users/{user}', [UserController::class, 'update']);
+    Route::delete('users/{user}', [UserController::class, 'destroy']);
+    // ...
+});
+```
+
+## 修正方針
+
+### 1. Laravel Sanctumの設定
+- Sanctumパッケージの設定確認
+- APIトークン認証の実装
+- CORSの適切な設定
+
+### 2. 認証ミドルウェアの追加
+```php
+Route::middleware(['auth:sanctum', 'throttle:60,1'])->group(function () {
+    // 書き込み系エンドポイント
+});
+```
+
+### 3. 読み取り専用エンドポイントの整理
+- GET系エンドポイントは認証不要のまま維持（要件次第）
+- または全APIを認証必須にする
+
+### 4. フロントエンドの対応
+- APIトークンの管理
+- 認証ヘッダーの追加
+- 認証エラーハンドリング
+
+## テスト項目
+- [ ] 認証なしでの書き込みAPIアクセスが拒否される
+- [ ] 有効なトークンでのアクセスが成功する
+- [ ] トークンの有効期限が適切に動作する
+- [ ] CORS設定が正しく動作する
+
+## 実装ステップ
+1. Sanctumの設定確認・調整
+2. ルートファイルに認証ミドルウェア追加
+3. 認証用エンドポイント（login/logout）の実装
+4. フロントエンドのAPI通信に認証ヘッダー追加
+5. テストの実施
+
+## 参考情報
+- [Laravel Sanctum Documentation](https://laravel.com/docs/10.x/sanctum)
+- [Laravel API Authentication](https://laravel.com/docs/10.x/authentication#api-authentication)

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { login } from '@/lib/api/auth';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      await login(email, password);
+      router.push('/users/list');
+    } catch (err) {
+      setError((err as Error).message || 'ログインに失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            ログイン
+          </h2>
+        </div>
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          {error && (
+            <div className="rounded-md bg-red-50 p-4">
+              <div className="text-sm text-red-800">{error}</div>
+            </div>
+          )}
+          <div className="rounded-md shadow-sm -space-y-px">
+            <div>
+              <label htmlFor="email" className="sr-only">
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                placeholder="メールアドレス"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="sr-only">
+                パスワード
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                required
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                placeholder="パスワード"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? 'ログイン中...' : 'ログイン'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -21,7 +21,7 @@ export const AuthToken = {
 };
 
 // 認証ヘッダーを取得
-export const getAuthHeaders = () => {
+export const getAuthHeaders = (): Record<string, string> => {
   const token = AuthToken.get();
   if (token) {
     return {

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -1,0 +1,97 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
+
+// 認証トークンの管理
+export const AuthToken = {
+  get: () => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('auth_token');
+    }
+    return null;
+  },
+  set: (token: string) => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('auth_token', token);
+    }
+  },
+  remove: () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('auth_token');
+    }
+  }
+};
+
+// 認証ヘッダーを取得
+export const getAuthHeaders = () => {
+  const token = AuthToken.get();
+  if (token) {
+    return {
+      'Authorization': `Bearer ${token}`
+    };
+  }
+  return {};
+};
+
+// ログイン
+export const login = async (email: string, password: string) => {
+  const response = await fetch(`${API_URL}/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      password,
+      device_name: 'web'
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.message || 'ログインに失敗しました');
+  }
+
+  const data = await response.json();
+  AuthToken.set(data.token);
+  return data;
+};
+
+// ログアウト
+export const logout = async () => {
+  const token = AuthToken.get();
+  if (!token) return;
+
+  try {
+    await fetch(`${API_URL}/logout`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+    });
+  } finally {
+    AuthToken.remove();
+  }
+};
+
+// 現在のユーザー情報を取得
+export const getCurrentUser = async () => {
+  const token = AuthToken.get();
+  if (!token) return null;
+
+  try {
+    const response = await fetch(`${API_URL}/user`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      },
+    });
+
+    if (!response.ok) {
+      AuthToken.remove();
+      return null;
+    }
+
+    return await response.json();
+  } catch {
+    return null;
+  }
+};

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -1,3 +1,5 @@
+import { getAuthHeaders } from './auth';
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 
 export interface User {
@@ -19,12 +21,14 @@ export interface User {
 
 // Fetch API helper function
 async function apiFetch(url: string, options: RequestInit = {}) {
+  const authHeaders = getAuthHeaders();
   const response = await fetch(url, {
+    ...options,
     headers: {
       "Content-Type": "application/json",
-      ...options.headers,
+      ...authHeaders,
+      ...(options.headers || {}),
     },
-    ...options,
   });
 
   if (!response.ok) {

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -211,23 +211,14 @@ export const bulkDeleteUsers = async (params: BulkOperationParams) => {
   try {
     console.log("Bulk delete params:", params); // デバッグ用
 
-    const response = await fetch(`${API_URL}/users/bulk-delete`, {
+    // apiFetchヘルパーを使用して認証ヘッダーを自動付与
+    const response = await apiFetch(`${API_URL}/users/bulk-delete`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify(params),
     });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      console.error("Bulk delete validation error:", errorData); // エラー詳細をログ出力
-      throw new Error(
-        errorData.error || errorData.message || `HTTP ${response.status}: ${response.statusText}`
-      );
-    }
-
-    return response.json();
+    // apiFetchがエラーハンドリングを行うため、直接レスポンスを返す
+    return response;
   } catch (error: unknown) {
     console.error("Error bulk deleting users:", error);
     throw error;
@@ -236,10 +227,13 @@ export const bulkDeleteUsers = async (params: BulkOperationParams) => {
 
 export const bulkExportUsers = async (params: BulkOperationParams) => {
   try {
+    // 認証ヘッダーを含むfetchを直接使用（blobレスポンスのため）
+    const authHeaders = getAuthHeaders();
     const response = await fetch(`${API_URL}/users/bulk-export-fast`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        ...authHeaders,
       },
       body: JSON.stringify(params),
     });
@@ -300,8 +294,11 @@ export const checkDuplicates = async (file: File) => {
     const formData = new FormData();
     formData.append("csv_file", file);
 
+    // 認証ヘッダーを追加（ファイルアップロードのためContent-Typeは設定しない）
+    const authHeaders = getAuthHeaders();
     const response = await fetch(`${API_URL}/users/check-duplicates`, {
       method: "POST",
+      headers: authHeaders,
       body: formData,
     });
 

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -22,13 +22,15 @@ export interface User {
 // Fetch API helper function
 async function apiFetch(url: string, options: RequestInit = {}) {
   const authHeaders = getAuthHeaders();
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    ...authHeaders,
+    ...(options.headers as Record<string, string> || {}),
+  };
+  
   const response = await fetch(url, {
     ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...authHeaders,
-      ...(options.headers || {}),
-    },
+    headers,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## 概要
書き込み系APIエンドポイントにLaravel Sanctumを使用した認証機能を実装しました。

## 実装内容
### バックエンド
- ✅ AuthControllerの追加（ログイン/ログアウト/ユーザー情報取得）
- ✅ Sanctumマイグレーションファイルの追加
- ✅ 書き込み系エンドポイントに`auth:sanctum`ミドルウェアを適用
  - POST /users（作成）
  - PUT /users/{id}（更新）
  - DELETE /users/{id}（削除）
  - POST /users/import（CSVインポート）
  - POST /users/bulk-delete（一括削除）
  - POST /users/bulk-export（一括エクスポート）

### フロントエンド
- ✅ 認証ヘルパー機能（auth.ts）
- ✅ ログインページの作成
- ✅ APIリクエストへの自動認証ヘッダー付与
- ✅ トークン管理（localStorage）

## セキュリティ向上
- 認証なしでの破壊的操作を防止
- トークンベースの認証でセッション管理
- デバイスごとのトークン管理

## テスト方法
1. マイグレーション実行: `docker compose exec backend php artisan migrate`
2. ログインページ（/login）からログイン
3. 認証が必要なAPIへのアクセスを確認

## 関連Issue
- #30: API認証の実装

🤖 Generated with [Claude Code](https://claude.ai/code)