### PR TITLE
fix: align bulk export endpoint (#50)

### DIFF
--- a/backend/tests/Feature/AuthenticationTest.php
+++ b/backend/tests/Feature/AuthenticationTest.php
@@ -169,17 +169,6 @@ class AuthenticationTest extends TestCase
     }
 
     /**
-     * 高速バルクエクスポートに認証が必要なことをテスト
-     */
-    public function test_bulk_export_fast_requires_authentication()
-    {
-        $response = $this->postJson('/api/users/bulk-export-fast', [
-            'user_ids' => [1, 2, 3],
-        ]);
-        $response->assertUnauthorized();
-    }
-
-    /**
      * 認証済みユーザーがCSV重複チェックを実行できることをテスト
      */
     public function test_authenticated_user_can_check_duplicates()

--- a/docs/AUTH_SETUP.md
+++ b/docs/AUTH_SETUP.md
@@ -82,7 +82,6 @@ curl -X POST http://localhost:8000/api/logout \
 - `POST /api/users/check-duplicates` - CSV重複チェック
 - `POST /api/users/bulk-delete` - 一括削除
 - `POST /api/users/bulk-export` - 一括エクスポート
-- `POST /api/users/bulk-export-fast` - 高速一括エクスポート
 
 ### 認証不要のエンドポイント（読み取り専用）
 
@@ -91,7 +90,6 @@ curl -X POST http://localhost:8000/api/logout \
 - `GET /api/users` - ユーザー一覧取得
 - `GET /api/users/{id}` - ユーザー詳細取得
 - `GET /api/users/export` - CSVエクスポート
-- `GET /api/users/export-fast` - 高速CSVエクスポート
 - `GET /api/users/sample-csv` - サンプルCSVダウンロード
 - `GET /api/users/status-counts` - ステータス別カウント取得
 - `GET /api/pagination` - ページネーション付きユーザー一覧

--- a/docs/issues/issue-50-fix-bulk-export-endpoint-mismatch.md
+++ b/docs/issues/issue-50-fix-bulk-export-endpoint-mismatch.md
@@ -5,8 +5,8 @@
 
 ## 対応方針
 いずれかで整合させる：
-1. フロントを `POST /users/bulk-export` に合わせる（推奨）
-2. バックエンドに `/users/bulk-export-fast` のエイリアスルートを追加
+1. フロントを `POST /users/bulk-export` に合わせる（対応済み）
+2. バックエンドに `/users/bulk-export-fast` のエイリアスルートを追加（不要）
 
 ## 影響範囲
 - `frontend/src/lib/api/users.ts`
@@ -18,3 +18,6 @@
 
 ## 参考
 - セキュリティレビュー（2025-08-10）: docs/reports/security-review-2025-08-10.md
+
+## ステータス
+2025-08-09: フロントエンドを `/users/bulk-export` に統一し、本Issueは解決済み。

--- a/docs/reports/security-review-2025-08-10.md
+++ b/docs/reports/security-review-2025-08-10.md
@@ -77,7 +77,7 @@
 - CORS 設定
   - `supports_credentials: true`。本番で `FRONTEND_URL` を厳密に。
 - 機能差分（セキュリティ影響は小）
-  - フロントが `POST /users/bulk-export-fast` を呼ぶが、バックエンドは `POST /users/bulk-export` のみ。
+  - フロントとバックエンドのエンドポイントは `/users/bulk-export` に統一された。
 
 ---
 

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -1,4 +1,4 @@
-import { getAuthHeaders } from './auth';
+import { getAuthHeaders } from "./auth";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 
@@ -25,9 +25,9 @@ async function apiFetch(url: string, options: RequestInit = {}) {
   const headers: HeadersInit = {
     "Content-Type": "application/json",
     ...authHeaders,
-    ...(options.headers as Record<string, string> || {}),
+    ...((options.headers as Record<string, string>) || {}),
   };
-  
+
   const response = await fetch(url, {
     ...options,
     headers,
@@ -173,7 +173,7 @@ export const importUsers = async (
 
 export const exportUsers = async () => {
   try {
-    const response = await fetch(`${API_URL}/users/export-fast`);
+    const response = await fetch(`${API_URL}/users/export`);
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -209,8 +209,6 @@ export interface BulkOperationParams {
 
 export const bulkDeleteUsers = async (params: BulkOperationParams) => {
   try {
-    console.log("Bulk delete params:", params); // デバッグ用
-
     // apiFetchヘルパーを使用して認証ヘッダーを自動付与
     const response = await apiFetch(`${API_URL}/users/bulk-delete`, {
       method: "POST",
@@ -229,7 +227,7 @@ export const bulkExportUsers = async (params: BulkOperationParams) => {
   try {
     // 認証ヘッダーを含むfetchを直接使用（blobレスポンスのため）
     const authHeaders = getAuthHeaders();
-    const response = await fetch(`${API_URL}/users/bulk-export-fast`, {
+    const response = await fetch(`${API_URL}/users/bulk-export`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- switch user export call to `/users/export`
- drop leftover `export-fast` references and debug logging
- mark bulk export mismatch issue resolved

## Testing
- `composer install --no-interaction` *(fails: unable to access GitHub repo, CONNECT tunnel failed, response 403)*
- `composer pint` *(fails: unable to download dependencies, response 403)*
- `composer test` *(fails: ./vendor/bin/phpunit not found)*
- `npm run lint`
- `npm run typecheck`
- `npm run format:check` *(warn: Code style issues found in 2 files)*

------
https://chatgpt.com/codex/tasks/task_e_689789ef4d84832983c4348f02e620b7