### PR TITLE
fix: align bulk export endpoint (#50)

### DIFF
--- a/backend/tests/Feature/AuthenticationTest.php
+++ b/backend/tests/Feature/AuthenticationTest.php
@@ -169,17 +169,6 @@ class AuthenticationTest extends TestCase
     }
 
     /**
-     * 高速バルクエクスポートに認証が必要なことをテスト
-     */
-    public function test_bulk_export_fast_requires_authentication()
-    {
-        $response = $this->postJson('/api/users/bulk-export-fast', [
-            'user_ids' => [1, 2, 3],
-        ]);
-        $response->assertUnauthorized();
-    }
-
-    /**
      * 認証済みユーザーがCSV重複チェックを実行できることをテスト
      */
     public function test_authenticated_user_can_check_duplicates()

--- a/docs/AUTH_SETUP.md
+++ b/docs/AUTH_SETUP.md
@@ -82,7 +82,6 @@ curl -X POST http://localhost:8000/api/logout \
 - `POST /api/users/check-duplicates` - CSV重複チェック
 - `POST /api/users/bulk-delete` - 一括削除
 - `POST /api/users/bulk-export` - 一括エクスポート
-- `POST /api/users/bulk-export-fast` - 高速一括エクスポート
 
 ### 認証不要のエンドポイント（読み取り専用）
 
@@ -91,7 +90,6 @@ curl -X POST http://localhost:8000/api/logout \
 - `GET /api/users` - ユーザー一覧取得
 - `GET /api/users/{id}` - ユーザー詳細取得
 - `GET /api/users/export` - CSVエクスポート
-- `GET /api/users/export-fast` - 高速CSVエクスポート
 - `GET /api/users/sample-csv` - サンプルCSVダウンロード
 - `GET /api/users/status-counts` - ステータス別カウント取得
 - `GET /api/pagination` - ページネーション付きユーザー一覧

--- a/docs/issues/issue-50-fix-bulk-export-endpoint-mismatch.md
+++ b/docs/issues/issue-50-fix-bulk-export-endpoint-mismatch.md
@@ -5,8 +5,8 @@
 
 ## 対応方針
 いずれかで整合させる：
-1. フロントを `POST /users/bulk-export` に合わせる（推奨）
-2. バックエンドに `/users/bulk-export-fast` のエイリアスルートを追加
+1. フロントを `POST /users/bulk-export` に合わせる（対応済み）
+2. バックエンドに `/users/bulk-export-fast` のエイリアスルートを追加（不要）
 
 ## 影響範囲
 - `frontend/src/lib/api/users.ts`
@@ -18,3 +18,6 @@
 
 ## 参考
 - セキュリティレビュー（2025-08-10）: docs/reports/security-review-2025-08-10.md
+
+## ステータス
+2025-08-09: フロントエンドを `/users/bulk-export` に統一し、本Issueは解決済み。

--- a/docs/reports/security-review-2025-08-10.md
+++ b/docs/reports/security-review-2025-08-10.md
@@ -77,7 +77,7 @@
 - CORS 設定
   - `supports_credentials: true`。本番で `FRONTEND_URL` を厳密に。
 - 機能差分（セキュリティ影響は小）
-  - フロントが `POST /users/bulk-export-fast` を呼ぶが、バックエンドは `POST /users/bulk-export` のみ。
+  - フロントとバックエンドのエンドポイントは `/users/bulk-export` に統一された。
 
 ---
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,26 +1,26 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { login } from '@/lib/api/auth';
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { login } from "@/lib/api/auth";
 
 export default function LoginPage() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError('');
+    setError("");
     setLoading(true);
 
     try {
       await login(email, password);
-      router.push('/users/list');
+      router.push("/users/list");
     } catch (err) {
-      setError((err as Error).message || 'ログインに失敗しました');
+      setError((err as Error).message || "ログインに失敗しました");
     } finally {
       setLoading(false);
     }
@@ -30,9 +30,7 @@ export default function LoginPage() {
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="max-w-md w-full space-y-8">
         <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            ログイン
-          </h2>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">ログイン</h2>
         </div>
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
@@ -81,7 +79,7 @@ export default function LoginPage() {
               disabled={loading}
               className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {loading ? 'ログイン中...' : 'ログイン'}
+              {loading ? "ログイン中..." : "ログイン"}
             </button>
           </div>
         </form>

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -3,21 +3,21 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 // 認証トークンの管理
 export const AuthToken = {
   get: () => {
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem('auth_token');
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("auth_token");
     }
     return null;
   },
   set: (token: string) => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('auth_token', token);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("auth_token", token);
     }
   },
   remove: () => {
-    if (typeof window !== 'undefined') {
-      localStorage.removeItem('auth_token');
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("auth_token");
     }
-  }
+  },
 };
 
 // 認証ヘッダーを取得
@@ -25,7 +25,7 @@ export const getAuthHeaders = (): Record<string, string> => {
   const token = AuthToken.get();
   if (token) {
     return {
-      'Authorization': `Bearer ${token}`
+      Authorization: `Bearer ${token}`,
     };
   }
   return {};
@@ -34,20 +34,20 @@ export const getAuthHeaders = (): Record<string, string> => {
 // ログイン
 export const login = async (email: string, password: string) => {
   const response = await fetch(`${API_URL}/login`, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
       email,
       password,
-      device_name: 'web'
+      device_name: "web",
     }),
   });
 
   if (!response.ok) {
     const error = await response.json();
-    throw new Error(error.message || 'ログインに失敗しました');
+    throw new Error(error.message || "ログインに失敗しました");
   }
 
   const data = await response.json();
@@ -62,10 +62,10 @@ export const logout = async () => {
 
   try {
     await fetch(`${API_URL}/logout`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
       },
     });
   } finally {
@@ -81,7 +81,7 @@ export const getCurrentUser = async () => {
   try {
     const response = await fetch(`${API_URL}/user`, {
       headers: {
-        'Authorization': `Bearer ${token}`
+        Authorization: `Bearer ${token}`,
       },
     });
 

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -1,4 +1,4 @@
-import { getAuthHeaders } from './auth';
+import { getAuthHeaders } from "./auth";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 
@@ -25,9 +25,9 @@ async function apiFetch(url: string, options: RequestInit = {}) {
   const headers: HeadersInit = {
     "Content-Type": "application/json",
     ...authHeaders,
-    ...(options.headers as Record<string, string> || {}),
+    ...((options.headers as Record<string, string>) || {}),
   };
-  
+
   const response = await fetch(url, {
     ...options,
     headers,
@@ -173,7 +173,7 @@ export const importUsers = async (
 
 export const exportUsers = async () => {
   try {
-    const response = await fetch(`${API_URL}/users/export-fast`);
+    const response = await fetch(`${API_URL}/users/export`);
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -209,8 +209,6 @@ export interface BulkOperationParams {
 
 export const bulkDeleteUsers = async (params: BulkOperationParams) => {
   try {
-    console.log("Bulk delete params:", params); // デバッグ用
-
     // apiFetchヘルパーを使用して認証ヘッダーを自動付与
     const response = await apiFetch(`${API_URL}/users/bulk-delete`, {
       method: "POST",
@@ -229,7 +227,7 @@ export const bulkExportUsers = async (params: BulkOperationParams) => {
   try {
     // 認証ヘッダーを含むfetchを直接使用（blobレスポンスのため）
     const authHeaders = getAuthHeaders();
-    const response = await fetch(`${API_URL}/users/bulk-export-fast`, {
+    const response = await fetch(`${API_URL}/users/bulk-export`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- switch user export call to `/users/export`
- drop leftover `export-fast` references and debug logging
- mark bulk export mismatch issue resolved
- format auth and login modules to satisfy Prettier

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `composer pint` *(fails: ./vendor/bin/pint not found)*
- `composer test` *(fails: ./vendor/bin/phpunit not found)*
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689789ef4d84832983c4348f02e620b7