### PR TITLE
fix: escape LIKE wildcards in user queries

### DIFF
--- a/backend/app/Http/Controllers/CsvController.php
+++ b/backend/app/Http/Controllers/CsvController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Support\QueryHelper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -840,10 +841,12 @@ class CsvController extends Controller
                         if (config('database.default') === 'mysql') {
                             $query->whereFullText(['name', 'email', 'phone_number'], $q);
                         } else {
-                            $query->where(function ($sub) use ($q) {
-                                $sub->where('name', 'like', "%{$q}%")
-                                    ->orWhere('email', 'like', "%{$q}%")
-                                    ->orWhere('phone_number', 'like', "%{$q}%");
+                            $escaped = QueryHelper::escapeLike($q);
+                            $like = "%{$escaped}%";
+                            $query->where(function ($sub) use ($like) {
+                                $sub->whereRaw("name LIKE ? ESCAPE '\\'", [$like])
+                                    ->orWhereRaw("email LIKE ? ESCAPE '\\'", [$like])
+                                    ->orWhereRaw("phone_number LIKE ? ESCAPE '\\'", [$like]);
                             });
                         }
                     }

--- a/backend/app/Http/Controllers/PaginationController.php
+++ b/backend/app/Http/Controllers/PaginationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Support\QueryHelper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Validation\Rule;
@@ -51,10 +52,12 @@ class PaginationController extends Controller
                 $query->whereFullText(['name', 'email', 'phone_number'], $q);
             } else {
                 // SQLite等の場合はLIKE検索（開発・テスト環境用）
-                $query->where(function ($sub) use ($q) {
-                    $sub->where('name', 'like', "%{$q}%")
-                        ->orWhere('email', 'like', "%{$q}%")
-                        ->orWhere('phone_number', 'like', "%{$q}%");
+                $escaped = QueryHelper::escapeLike($q);
+                $like = "%{$escaped}%";
+                $query->where(function ($sub) use ($like) {
+                    $sub->whereRaw("name LIKE ? ESCAPE '\\'", [$like])
+                        ->orWhereRaw("email LIKE ? ESCAPE '\\'", [$like])
+                        ->orWhereRaw("phone_number LIKE ? ESCAPE '\\'", [$like]);
                 });
             }
         }
@@ -142,10 +145,12 @@ class PaginationController extends Controller
                 $baseQuery->whereFullText(['name', 'email', 'phone_number'], $q);
             } else {
                 // SQLite等の場合はLIKE検索（開発・テスト環境用）
-                $baseQuery->where(function ($sub) use ($q) {
-                    $sub->where('name', 'like', "%{$q}%")
-                        ->orWhere('email', 'like', "%{$q}%")
-                        ->orWhere('phone_number', 'like', "%{$q}%");
+                $escaped = QueryHelper::escapeLike($q);
+                $like = "%{$escaped}%";
+                $baseQuery->where(function ($sub) use ($like) {
+                    $sub->whereRaw("name LIKE ? ESCAPE '\\'", [$like])
+                        ->orWhereRaw("email LIKE ? ESCAPE '\\'", [$like])
+                        ->orWhereRaw("phone_number LIKE ? ESCAPE '\\'", [$like]);
                 });
             }
         }

--- a/backend/app/Support/QueryHelper.php
+++ b/backend/app/Support/QueryHelper.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Support;
+
+class QueryHelper
+{
+    public static function escapeLike(string $value, string $escapeChar = '\\'): string
+    {
+        return str_replace(
+            [$escapeChar, '%', '_'],
+            [$escapeChar.$escapeChar, $escapeChar.'%', $escapeChar.'_'],
+            $value
+        );
+    }
+}
+

--- a/backend/tests/Feature/PaginationControllerTest.php
+++ b/backend/tests/Feature/PaginationControllerTest.php
@@ -115,6 +115,22 @@ class PaginationControllerTest extends TestCase
     }
 
     /**
+     * LIKE検索でワイルドカード文字がエスケープされることをテスト
+     */
+    public function test_pagination_controller_escapes_like_wildcards()
+    {
+        User::factory(3)->create();
+
+        $response = $this->getJson('/api/users?q=%');
+        $response->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+
+        $response = $this->getJson('/api/users?q=_');
+        $response->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+    }
+
+    /**
      * ステータスフィルタのテスト
      */
     public function test_pagination_controller_status_filter()


### PR DESCRIPTION
## Summary
- sanitize wildcard characters in user search filters
- cover wildcard escaping with pagination tests

## Testing
- `composer test` *(fails: vendor/bin/phpunit not found, composer install blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897aec279b083299d7dfb4e2043084e