### PR TITLE
test: add gzip compression middleware tests

### DIFF
--- a/backend/tests/Feature/CompressResponseTest.php
+++ b/backend/tests/Feature/CompressResponseTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class CompressResponseTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_response_is_gzipped_when_client_accepts(): void
+    {
+        User::factory()->count(50)->create();
+
+        $response = $this->getJson('/api/users', ['Accept-Encoding' => 'gzip']);
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Encoding', 'gzip');
+
+        $compressed = $response->getContent();
+        $decompressed = gzdecode($compressed);
+
+        $this->assertNotFalse($decompressed);
+        $this->assertJson($decompressed);
+        $this->assertGreaterThan(strlen($compressed), strlen($decompressed));
+    }
+
+    public function test_response_is_not_gzipped_without_accept_encoding(): void
+    {
+        User::factory()->count(50)->create();
+
+        $response = $this->getJson('/api/users');
+
+        $response->assertStatus(200);
+        $response->assertHeaderMissing('Content-Encoding');
+    }
+}
+


### PR DESCRIPTION
## Summary
- add test coverage for gzip API response compression middleware

## Testing
- `cd backend && composer pint` *(fails: ./vendor/bin/pint - not found)*
- `cd backend && composer install` *(fails: CONNECT tunnel failed: 403)*
- `cd backend && composer test` *(fails: dependency downloads blocked 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897b1331ac08329a3cf54c7c0b4b975