### PR TITLE
test: authenticate protected API tests

### DIFF
--- a/backend/tests/Feature/AuthenticationTest.php
+++ b/backend/tests/Feature/AuthenticationTest.php
@@ -108,6 +108,10 @@ class AuthenticationTest extends TestCase
 
         $this->getJson('/api/users')->assertUnauthorized();
         $this->getJson('/api/users/export')->assertUnauthorized();
+        $this->getJson('/api/users/sample-csv')->assertUnauthorized();
+        $this->getJson('/api/pagination')->assertUnauthorized();
+        $this->getJson('/api/pagination/status-counts')->assertUnauthorized();
+        $this->getJson('/api/users/status-counts')->assertUnauthorized();
     }
 
     /**

--- a/backend/tests/Feature/CacheManagementTest.php
+++ b/backend/tests/Feature/CacheManagementTest.php
@@ -11,6 +11,12 @@ class CacheManagementTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     /**
      * タグ付きキャッシュが正しく保存されることをテスト
      */

--- a/backend/tests/Feature/CsvApiTest.php
+++ b/backend/tests/Feature/CsvApiTest.php
@@ -12,6 +12,12 @@ class CsvApiTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     public function test_can_import_csv(): void
     {
         Storage::fake('local');

--- a/backend/tests/Feature/CsvExportValidationTest.php
+++ b/backend/tests/Feature/CsvExportValidationTest.php
@@ -10,6 +10,12 @@ class CsvExportValidationTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     /**
      * 不正なstatusパラメータが拒否されることをテスト
      */

--- a/backend/tests/Feature/CsvImportPasswordTest.php
+++ b/backend/tests/Feature/CsvImportPasswordTest.php
@@ -12,6 +12,12 @@ class CsvImportPasswordTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     /**
      * 新規ユーザー作成時にパスワードが正しく設定されることをテスト
      */

--- a/backend/tests/Feature/CsvMemoryTest.php
+++ b/backend/tests/Feature/CsvMemoryTest.php
@@ -11,6 +11,12 @@ class CsvMemoryTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     /**
      * CSVエクスポートのメモリ使用量をテスト
      */

--- a/backend/tests/Feature/PaginationControllerTest.php
+++ b/backend/tests/Feature/PaginationControllerTest.php
@@ -10,6 +10,12 @@ class PaginationControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     /**
      * PaginationControllerのデフォルトページネーションテスト
      * GET /api/usersエンドポイントの実際の動作を確認

--- a/backend/tests/Feature/PaginationTest.php
+++ b/backend/tests/Feature/PaginationTest.php
@@ -10,6 +10,12 @@ class PaginationTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     public function test_default_pagination()
     {
         User::factory()->count(30)->create();

--- a/backend/tests/Feature/SearchPerformanceTest.php
+++ b/backend/tests/Feature/SearchPerformanceTest.php
@@ -11,6 +11,12 @@ class SearchPerformanceTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     /**
      * フルテキスト検索のパフォーマンステスト
      */

--- a/backend/tests/Feature/UserApiTest.php
+++ b/backend/tests/Feature/UserApiTest.php
@@ -10,6 +10,12 @@ class UserApiTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     public function test_can_create_user(): void
     {
         $userData = [

--- a/backend/tests/Feature/UserPaginationTest.php
+++ b/backend/tests/Feature/UserPaginationTest.php
@@ -10,6 +10,12 @@ class UserPaginationTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
     /**
      * デフォルトのページネーションをテスト
      */

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -5,6 +5,8 @@ namespace Tests;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\DB;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -82,5 +84,15 @@ abstract class TestCase extends BaseTestCase
     {
         $userCount = $this->getTableCount('users');
         echo "\n[DEBUG] {$context}: users table has {$userCount} records\n";
+    }
+
+    /**
+     * 認証済みユーザーとしてテストを実行
+     */
+    protected function authenticate(?User $user = null): User
+    {
+        $user = $user ?? User::factory()->create();
+        Sanctum::actingAs($user);
+        return $user;
     }
 }


### PR DESCRIPTION
## Summary
- add authenticate() helper and update feature tests for Sanctum
- extend auth coverage for sample CSV and pagination routes

## Testing
- `composer test` *(failed: ./vendor/bin/phpunit not found)*
- `composer install` *(failed: CONNECT tunnel failed, response 403)*
- `composer pint` *(failed: CONNECT tunnel failed, response 403)*

Refs: #30

------
https://chatgpt.com/codex/tasks/task_e_6897b1e340248329882e7242cd5c717f