### PR TITLE
fix(frontend): remove dangerous innerHTML in CSV preview

### DIFF
--- a/frontend/src/app/(main)/users/import/page.tsx
+++ b/frontend/src/app/(main)/users/import/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, lazy, Suspense } from "react";
 import Link from "next/link";
 import { importUsers, downloadSampleCSV, checkDuplicates } from "@/lib/api/users";
+import { highlightText } from "@/lib/highlight";
 import {
   Button,
   Card,
@@ -745,17 +746,7 @@ export default function ImportUsersPage() {
                                 <TableHead className="w-16">#</TableHead>
                                 {csvPreview.headers.map((header, index) => (
                                   <TableHead key={index}>
-                                    {header}
-                                    {searchQuery && (
-                                      <span
-                                        dangerouslySetInnerHTML={{
-                                          __html: header.replace(
-                                            new RegExp(`(${searchQuery})`, "gi"),
-                                            '<mark class="bg-yellow-200 dark:bg-yellow-800">$1</mark>'
-                                          ),
-                                        }}
-                                      />
-                                    )}
+                                    {highlightText(header, searchQuery)}
                                   </TableHead>
                                 ))}
                               </TableRow>
@@ -773,18 +764,7 @@ export default function ImportUsersPage() {
                                     </TableCell>
                                     {row.map((cell, cellIndex) => (
                                       <TableCell key={cellIndex}>
-                                        {searchQuery ? (
-                                          <span
-                                            dangerouslySetInnerHTML={{
-                                              __html: cell.replace(
-                                                new RegExp(`(${searchQuery})`, "gi"),
-                                                '<mark class="bg-yellow-200 dark:bg-yellow-800">$1</mark>'
-                                              ),
-                                            }}
-                                          />
-                                        ) : (
-                                          cell
-                                        )}
+                                        {highlightText(cell, searchQuery)}
                                       </TableCell>
                                     ))}
                                   </TableRow>

--- a/frontend/src/lib/highlight.tsx
+++ b/frontend/src/lib/highlight.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function highlightText(text: string, query: string): React.ReactNode {
+  if (!query) return text;
+  const regex = new RegExp(`(${escapeRegExp(query)})`, "gi");
+  return text.split(regex).map((part, index) =>
+    part.toLowerCase() === query.toLowerCase() ? (
+      <mark key={index} className="bg-yellow-200 dark:bg-yellow-800">
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable highlightText utility for safe search term highlighting
- refactor user import preview to use React nodes instead of dangerouslySetInnerHTML

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format:check` *(fails: Code style issues found in 10 files)*


------
https://chatgpt.com/codex/tasks/task_e_6897b56ec074832998ad964818fd8a1a