### PR TITLE
feat: improve frontend API typing

### DIFF
--- a/frontend/src/app/(main)/page.tsx
+++ b/frontend/src/app/(main)/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
       // ステータスカウント結果を処理
       const statusCounts =
         statusCountsResult.status === "fulfilled"
-          ? statusCountsResult.value
+          ? statusCountsResult.value.data
           : { total: 0, active: 0, pending: 0, inactive: 0, expired: 0 };
 
       // 新規ユーザー数を処理

--- a/frontend/src/app/(main)/users/delete/[id]/page.tsx
+++ b/frontend/src/app/(main)/users/delete/[id]/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { fetchUser, deleteUser, User } from "@/lib/api/users";
+import { fetchUser, deleteUser } from "@/lib/api/users";
+import { User } from "@/types/user";
 
 export default function DeleteUserPage() {
   const params = useParams();
@@ -20,7 +21,7 @@ export default function DeleteUserPage() {
     const loadUser = async () => {
       try {
         setLoading(true);
-        const userData = await fetchUser(userId);
+        const { data: userData } = await fetchUser(userId);
         setUser(userData);
         setError(null);
       } catch (err) {

--- a/frontend/src/app/(main)/users/detail/[id]/page.tsx
+++ b/frontend/src/app/(main)/users/detail/[id]/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import { fetchUser, User, deleteUser } from "@/lib/api/users";
+import { fetchUser, deleteUser } from "@/lib/api/users";
+import { User } from "@/types/user";
 import { Button, Card, CardHeader, CardTitle, CardContent, Alert, Badge } from "@/components/ui";
 import DeleteConfirmModal from "@/components/DeleteConfirmModal";
 
@@ -22,7 +23,7 @@ export default function UserDetailPage() {
     const loadUser = async () => {
       try {
         setLoading(true);
-        const userData = await fetchUser(userId);
+        const { data: userData } = await fetchUser(userId);
         setUser(userData);
         setError(null);
       } catch (err) {

--- a/frontend/src/app/(main)/users/edit/[id]/page.tsx
+++ b/frontend/src/app/(main)/users/edit/[id]/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import { fetchUser, updateUser, User } from "@/lib/api/users";
+import { fetchUser, updateUser } from "@/lib/api/users";
+import { User } from "@/types/user";
 import {
   Button,
   Input,
@@ -42,7 +43,7 @@ export default function EditUserPage() {
     const loadUser = async () => {
       try {
         setLoading(true);
-        const userData = await fetchUser(userId);
+        const { data: userData } = await fetchUser(userId);
 
         setFormData({
           name: userData.name || "",

--- a/frontend/src/app/(main)/users/import/page.tsx
+++ b/frontend/src/app/(main)/users/import/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, lazy, Suspense } from "react";
 import Link from "next/link";
 import { importUsers, downloadSampleCSV, checkDuplicates } from "@/lib/api/users";
+import { isApiError } from "@/types/api";
 import {
   Button,
   Card,
@@ -115,6 +116,16 @@ interface DuplicateDetails {
     email: string;
     phone_number?: string;
   }>;
+}
+
+interface DuplicateCheckResult {
+  analysis: DuplicateAnalysis;
+  details: DuplicateDetails;
+}
+
+interface DuplicateCheckResult {
+  analysis: DuplicateAnalysis;
+  details: DuplicateDetails;
 }
 
 export default function ImportUsersPage() {
@@ -285,7 +296,7 @@ export default function ImportUsersPage() {
     setError(null);
 
     try {
-      const result = await checkDuplicates(file);
+      const { data: result } = await checkDuplicates<DuplicateCheckResult>(file);
       setDuplicateAnalysis(result.analysis);
       setDuplicateDetails(result.details);
 
@@ -296,7 +307,10 @@ export default function ImportUsersPage() {
       setCurrentStep(3);
     } catch (err: unknown) {
       console.error("Duplicate check error:", err);
-      setError("重複チェック中にエラーが発生しました。ネットワーク接続を確認してください。");
+      const message = isApiError(err)
+        ? err.message
+        : "重複チェック中にエラーが発生しました。ネットワーク接続を確認してください。";
+      setError(message);
     } finally {
       setCheckingDuplicates(false);
     }
@@ -364,7 +378,7 @@ export default function ImportUsersPage() {
       setSuccess(null);
       setImportResult(null);
 
-      const result = await importUsers(file, importStrategy);
+      const { data: result } = await importUsers<ImportResult>(file, importStrategy);
 
       setImportResult(result);
 
@@ -384,7 +398,7 @@ export default function ImportUsersPage() {
             );
           }
         } else {
-          setSuccess(result.message);
+          setSuccess(result.message ?? null);
         }
       }
 
@@ -392,16 +406,15 @@ export default function ImportUsersPage() {
     } catch (err: unknown) {
       console.error("Import error:", err);
 
-      if (err && typeof err === "object" && "response" in err) {
-        const errorWithResponse = err as { response?: { status?: number } };
-        if (errorWithResponse.response?.status === 422) {
+      if (isApiError(err)) {
+        if (err.code === 422) {
           setError("入力データに問題があります。CSVファイルの内容を確認してください。");
-        } else if (errorWithResponse.response?.status) {
+        } else if (err.code) {
           setError(
-            `サーバーエラーが発生しました。しばらく時間をおいて再度お試しください。（エラーコード: ${errorWithResponse.response.status}）`
+            `サーバーエラーが発生しました。しばらく時間をおいて再度お試しください。（エラーコード: ${err.code}）`
           );
         } else {
-          setError("インポート処理中にエラーが発生しました。");
+          setError(err.message);
         }
       } else {
         setError("インポート処理中にエラーが発生しました。ネットワーク接続を確認してください。");

--- a/frontend/src/app/(main)/users/list/page.tsx
+++ b/frontend/src/app/(main)/users/list/page.tsx
@@ -11,7 +11,7 @@ import {
   deleteUser,
 } from "@/lib/api/users";
 import Link from "next/link";
-import { User } from "@/lib/api/users";
+import { User } from "@/types/user";
 import { SearchField } from "@/components/SearchField";
 import { Button, Alert } from "@/components/ui";
 import DeleteConfirmModal from "@/components/DeleteConfirmModal";
@@ -134,7 +134,7 @@ function UserListContent() {
   // ステータスカウントを取得する関数
   const loadStatusCounts = useCallback(async () => {
     try {
-      const counts = await fetchStatusCounts({ q: searchQuery || undefined });
+      const { data: counts } = await fetchStatusCounts({ q: searchQuery || undefined });
       setStatusCounts(counts);
     } catch (err) {
       console.error("Failed to load status counts:", err);
@@ -175,15 +175,19 @@ function UserListContent() {
         }
 
         const res = await fetchUsers(params);
-
-        // サーバーサイドページネーションのレスポンスを処理
-        if (res?.data) {
-          setUsers(res.data);
-          setMeta(res.meta);
-        } else {
-          // 古い形式のレスポンスの場合
-          setUsers(res || []);
-        }
+        setUsers(res.data);
+        setMeta(
+          res.meta
+            ? {
+                total: res.meta.total,
+                current_page: res.meta.current_page,
+                per_page: res.meta.per_page,
+                last_page: res.meta.last_page,
+                from: res.meta.from ?? null,
+                to: res.meta.to ?? null,
+              }
+            : null
+        );
         setError(null);
       } catch (err) {
         setError("ユーザーデータの取得に失敗しました。");
@@ -430,10 +434,19 @@ function UserListContent() {
           created: filters.created?.[0],
         });
 
-        if (res?.data) {
-          setUsers(res.data);
-          setMeta(res.meta);
-        }
+        setUsers(res.data);
+        setMeta(
+          res.meta
+            ? {
+                total: res.meta.total,
+                current_page: res.meta.current_page,
+                per_page: res.meta.per_page,
+                last_page: res.meta.last_page,
+                from: res.meta.from ?? null,
+                to: res.meta.to ?? null,
+              }
+            : null
+        );
       } else {
         // バルク削除
         const params = prepareBulkParams();
@@ -451,10 +464,19 @@ function UserListContent() {
           created: filters.created?.[0],
         });
 
-        if (res?.data) {
-          setUsers(res.data);
-          setMeta(res.meta);
-        }
+        setUsers(res.data);
+        setMeta(
+          res.meta
+            ? {
+                total: res.meta.total,
+                current_page: res.meta.current_page,
+                per_page: res.meta.per_page,
+                last_page: res.meta.last_page,
+                from: res.meta.from ?? null,
+                to: res.meta.to ?? null,
+              }
+            : null
+        );
       }
 
       // ステータスカウントも更新

--- a/frontend/src/components/DeleteConfirmModal.tsx
+++ b/frontend/src/components/DeleteConfirmModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { User } from "@/lib/api/users";
+import { User } from "@/types/user";
 
 interface DeleteConfirmModalProps {
   isOpen: boolean;

--- a/frontend/src/components/UserTable.tsx
+++ b/frontend/src/components/UserTable.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo, useCallback, memo } from "react";
 import Link from "next/link";
-import { User } from "@/lib/api/users";
+import { User } from "@/types/user";
 import { Badge } from "@/components/ui";
 import { cn } from "@/lib/utils";
 

--- a/frontend/src/components/VirtualTable.tsx
+++ b/frontend/src/components/VirtualTable.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useRef, useCallback, memo } from "react";
 import { FixedSizeList as List } from "react-window";
-import { User } from "@/lib/api/users";
+import { User } from "@/types/user";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui";
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,21 @@
+export interface ApiResponse<T> {
+  data: T;
+  meta?: {
+    current_page: number;
+    per_page: number;
+    total: number;
+    last_page: number;
+    from?: number;
+    to?: number;
+  };
+}
+
+export interface ApiError {
+  message: string;
+  errors?: Record<string, string[]>;
+  code?: number;
+}
+
+export const isApiError = (error: unknown): error is ApiError => {
+  return typeof error === "object" && error !== null && "message" in error;
+};

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,0 +1,16 @@
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  phone_number?: string;
+  address?: string;
+  birth_date?: string;
+  gender?: "male" | "female" | "other";
+  membership_status?: "active" | "inactive" | "pending" | "expired";
+  notes?: string;
+  profile_image?: string;
+  points?: number;
+  last_login_at?: string;
+  created_at?: string;
+  updated_at?: string;
+}


### PR DESCRIPTION
## Summary
- add shared `ApiResponse` and `ApiError` types with guard
- centralize `User` interface and update API layer to use it
- adjust user pages to consume typed responses

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format:check` *(fails: Code style issues found in 9 files)*

Closes #42

------
https://chatgpt.com/codex/tasks/task_e_6897b5fbe37483298ff373024d981cd6