### PR TITLE
refactor: centralize user search logic

### DIFF
--- a/backend/app/Http/Controllers/CsvController.php
+++ b/backend/app/Http/Controllers/CsvController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
-use App\Support\QueryHelper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -837,18 +836,7 @@ class CsvController extends Controller
 
                     // 検索条件を適用（PaginationControllerと同じロジック）
                     if (! empty($filters['q'])) {
-                        $q = $filters['q'];
-                        if (config('database.default') === 'mysql') {
-                            $query->whereFullText(['name', 'email', 'phone_number'], $q);
-                        } else {
-                            $escaped = QueryHelper::escapeLike($q);
-                            $like = "%{$escaped}%";
-                            $query->where(function ($sub) use ($like) {
-                                $sub->whereRaw("name LIKE ? ESCAPE '\\'", [$like])
-                                    ->orWhereRaw("email LIKE ? ESCAPE '\\'", [$like])
-                                    ->orWhereRaw("phone_number LIKE ? ESCAPE '\\'", [$like]);
-                            });
-                        }
+                        $query->search($filters['q']);
                     }
 
                     // ステータスフィルタ

--- a/backend/app/Http/Controllers/PaginationController.php
+++ b/backend/app/Http/Controllers/PaginationController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
-use App\Support\QueryHelper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Validation\Rule;
@@ -47,19 +46,7 @@ class PaginationController extends Controller
 
         // 検索条件（フルテキスト検索を優先）
         if ($q !== null && $q !== '') {
-            if (config('database.default') === 'mysql') {
-                // MySQLの場合はフルテキスト検索を使用
-                $query->whereFullText(['name', 'email', 'phone_number'], $q);
-            } else {
-                // SQLite等の場合はLIKE検索（開発・テスト環境用）
-                $escaped = QueryHelper::escapeLike($q);
-                $like = "%{$escaped}%";
-                $query->where(function ($sub) use ($like) {
-                    $sub->whereRaw("name LIKE ? ESCAPE '\\'", [$like])
-                        ->orWhereRaw("email LIKE ? ESCAPE '\\'", [$like])
-                        ->orWhereRaw("phone_number LIKE ? ESCAPE '\\'", [$like]);
-                });
-            }
+            $query->search($q);
         }
 
         // ステータスフィルタ（複数対応）
@@ -140,19 +127,7 @@ class PaginationController extends Controller
 
         // 検索条件がある場合は適用（フルテキスト検索を優先）
         if ($q !== null && $q !== '') {
-            if (config('database.default') === 'mysql') {
-                // MySQLの場合はフルテキスト検索を使用
-                $baseQuery->whereFullText(['name', 'email', 'phone_number'], $q);
-            } else {
-                // SQLite等の場合はLIKE検索（開発・テスト環境用）
-                $escaped = QueryHelper::escapeLike($q);
-                $like = "%{$escaped}%";
-                $baseQuery->where(function ($sub) use ($like) {
-                    $sub->whereRaw("name LIKE ? ESCAPE '\\'", [$like])
-                        ->orWhereRaw("email LIKE ? ESCAPE '\\'", [$like])
-                        ->orWhereRaw("phone_number LIKE ? ESCAPE '\\'", [$like]);
-                });
-            }
+            $baseQuery->search($q);
         }
 
         // 各ステータスのカウントを取得

--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreUserRequest;
 use App\Http\Requests\UpdateUserRequest;
 use App\Models\User;
-use App\Support\QueryHelper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -183,18 +182,7 @@ class UserController extends Controller
 
                     // 検索条件を適用
                     if (! empty($filters['q'])) {
-                        $q = $filters['q'];
-                        if (config('database.default') === 'mysql') {
-                            $query->whereFullText(['name', 'email', 'phone_number'], $q);
-                        } else {
-                            $escaped = QueryHelper::escapeLike($q);
-                            $like = "%{$escaped}%";
-                            $query->where(function ($sub) use ($like) {
-                                $sub->whereRaw("name LIKE ? ESCAPE '\\'", [$like])
-                                    ->orWhereRaw("email LIKE ? ESCAPE '\\'", [$like])
-                                    ->orWhereRaw("phone_number LIKE ? ESCAPE '\\'", [$like]);
-                            });
-                        }
+                        $query->search($filters['q']);
                     }
 
                     // ステータスフィルタ

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Support\QueryHelper;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -48,4 +50,27 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    /**
+     * Scope a query to apply keyword search across name, email and phone number.
+     */
+    public function scopeSearch(Builder $query, string $q): Builder
+    {
+        if ($q === '') {
+            return $query;
+        }
+
+        if (config('database.default') === 'mysql') {
+            return $query->whereFullText(['name', 'email', 'phone_number'], $q);
+        }
+
+        $escaped = QueryHelper::escapeLike($q);
+        $like = "%{$escaped}%";
+
+        return $query->where(function (Builder $sub) use ($like) {
+            $sub->whereRaw("name LIKE ? ESCAPE '\\'", [$like])
+                ->orWhereRaw("email LIKE ? ESCAPE '\\'", [$like])
+                ->orWhereRaw("phone_number LIKE ? ESCAPE '\\'", [$like]);
+        });
+    }
 }

--- a/docs/issues/issue-23-search-optimization.md
+++ b/docs/issues/issue-23-search-optimization.md
@@ -87,18 +87,12 @@ $results = $index->search($q, [
 
 2. **検索ロジック更新**
    ```php
-   // MySQLではフルテキスト検索を使用
-   $query->whereFullText(['name', 'email', 'phone_number'], $q);
-   
-   // SQLiteでは従来のLIKE検索（テスト環境用）
-   $query->where(function ($sub) use ($q) {
-       $sub->where('name', 'like', "%{$q}%")
-           ->orWhere('email', 'like', "%{$q}%")
-           ->orWhere('phone_number', 'like', "%{$q}%");
-   });
+   // UserモデルのスコープでDBごとの検索処理を統一
+   $query->search($q);
    ```
 
 3. **実装ファイル**
    - マイグレーション: `2025_08_06_190000_add_fulltext_index_to_users_table.php`
-   - コントローラー: `PaginationController.php` (Line 34-45, 112-123)
+   - モデル: `User.php` (`scopeSearch`)
+   - コントローラー: `PaginationController.php` / `UserController.php` / `CsvController.php`
    - テスト: `SearchPerformanceTest.php`


### PR DESCRIPTION
## Summary
- add `scopeSearch` on `User` model to handle full-text or LIKE search
- use the new scope across pagination, CSV export and user bulk delete controllers
- document search scope in issue 23 notes

## Testing
- `composer pint` *(fails: ./vendor/bin/pint - not found)*
- `composer test` *(fails: ./vendor/bin/phpunit - not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897c0f5b3208329a55494ef247aa90c