### PR TITLE
docs: update backend version to Laravel 10

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,7 +7,7 @@
 **技術スタック:**
 
 *   **フロントエンド:** Next.js, TypeScript, Tailwind CSS, shadcn/ui
-*   **バックエンド:** Laravel 11, PHP 8.1, MySQL 8.0
+*   **バックエンド:** Laravel 10, PHP 8.1, MySQL 8.0
 *   **インフラ:** Docker, Docker Compose
 
 ## ビルドと実行

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## 技術スタック
 
 - **フロントエンド**: Next.js 15, TypeScript, Tailwind CSS 4, react-window
-- **バックエンド**: Laravel 11, PHP 8.1, MySQL 8.0
+- **バックエンド**: Laravel 10, PHP 8.1, MySQL 8.0
 - **インフラ**: Docker, Docker Compose
 
 ## パフォーマンス最適化済み


### PR DESCRIPTION
## Summary
- fix backend framework version in README
- sync GEMINI guide with Laravel 10

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: ./vendor/bin/phpunit: not found)*
- `composer run pint` *(fails: ./vendor/bin/pint: not found)*

Closes #26

------
https://chatgpt.com/codex/tasks/task_e_6897c17c21c88329ae1347e968803356