### PR TITLE
test: cover small response compression

### DIFF
--- a/backend/tests/Feature/CompressResponseTest.php
+++ b/backend/tests/Feature/CompressResponseTest.php
@@ -36,5 +36,16 @@ class CompressResponseTest extends TestCase
         $response->assertStatus(200);
         $response->assertHeaderMissing('Content-Encoding');
     }
+
+    public function test_small_response_is_not_gzipped_even_if_client_accepts(): void
+    {
+        User::factory()->create();
+
+        $response = $this->getJson('/api/users', ['Accept-Encoding' => 'gzip']);
+
+        $response->assertStatus(200);
+        $response->assertHeaderMissing('Content-Encoding');
+        $this->assertLessThan(1024, strlen($response->getContent()));
+    }
 }
 


### PR DESCRIPTION
## Summary
- test small API responses remain uncompressed despite gzip support

## Testing
- `composer install` *(fails: requires GitHub token)*
- `cd backend && ./vendor/bin/pint` *(fails: No such file or directory)*
- `cd backend && composer test` *(fails: ./vendor/bin/phpunit not found)*

## Issue
- Closes #25

------
https://chatgpt.com/codex/tasks/task_e_6897c1b6eac08329856bf5157043a7c6